### PR TITLE
Adjust error handling and more tests

### DIFF
--- a/resolvers.go
+++ b/resolvers.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/magiconair/properties"
 	"github.com/mattn/go-shellwords"
@@ -183,26 +184,18 @@ func (a *ArtifactResolver) ResolveMany(applicationPath string) ([]string, error)
 	}
 
 	if len(badPatterns) > 0 {
-		return []string{}, fmt.Errorf("unable to proceed due to bad pattern(s):%s", patternsToString(badPatterns))
+		return []string{}, fmt.Errorf("unable to proceed due to bad pattern(s):\n%s", strings.Join(badPatterns, "\n"))
 	}
 
 	if len(candidates) > 0 {
 		return candidates, nil
 	}
 
-	helpMsg := fmt.Sprintf("unable to find any built artifacts for pattern(s):%s", patternsToString(patterns))
+	helpMsg := fmt.Sprintf("unable to find any built artifacts for pattern(s):\n%s", strings.Join(patterns, "\n"))
 	if len(a.AdditionalHelpMessage) > 0 {
 		helpMsg = fmt.Sprintf("%s. %s", helpMsg, a.AdditionalHelpMessage)
 	}
 	return []string{}, fmt.Errorf(helpMsg)
-}
-
-func patternsToString(patterns []string) string {
-	msg := ""
-	for _, pattern := range patterns {
-		msg = fmt.Sprintf("%s\n%s", msg, pattern)
-	}
-	return msg
 }
 
 // ResolveArguments resolves the arguments that should be passed to a build system.

--- a/resolvers_test.go
+++ b/resolvers_test.go
@@ -224,7 +224,7 @@ func testResolvers(t *testing.T, context spec.G, it spec.S) {
 				ArtifactConfigurationKey: "TEST_ARTIFACT_CONFIGURATION_KEY",
 				ConfigurationResolver: libpak.ConfigurationResolver{
 					Configurations: []libpak.BuildpackConfiguration{
-						{Name: "TEST_ARTIFACT_CONFIGURATION_KEY", Default: "test-* target/*-runner.jar target/lib"},
+						{Name: "TEST_ARTIFACT_CONFIGURATION_KEY", Default: "test-*"},
 					},
 				},
 				ModuleConfigurationKey:  "TEST_MODULE_CONFIGURATION_KEY",
@@ -268,16 +268,63 @@ func testResolvers(t *testing.T, context spec.G, it spec.S) {
 		it("fails with zero candidates", func() {
 			_, err := resolver.ResolveMany(path)
 
-			Expect(err).To(MatchError(HavePrefix(`unable to find any built artifacts for pattern: "test-* target/*-runner.jar target/lib"`)))
+			Expect(err).To(MatchError(HavePrefix("unable to find any built artifacts for pattern(s):\ntest-*")))
 		})
 
-		it("passes with multiple space separated globs", func() {
-			Expect(os.Mkdir(filepath.Join(path, "target"), os.ModePerm)).To(Succeed())
-			runnerJarPath := filepath.Join(path, "target", "function-1.0.0-SNAPSHOT-runner.jar")
-			Expect(ioutil.WriteFile(runnerJarPath, []byte{}, 0644)).To(Succeed())
-			libPath := filepath.Join(path, "target", "lib")
-			Expect(os.Mkdir(libPath, os.ModePerm)).To(Succeed())
-			Expect(resolver.ResolveMany(path)).To(Equal([]string{runnerJarPath, libPath}))
+		context("ResolveMany with multiple glob patterns", func() {
+			it.Before(func() {
+				resolver.ConfigurationResolver.Configurations[0] = libpak.BuildpackConfiguration{
+					Name: "TEST_ARTIFACT_CONFIGURATION_KEY", Default: "test-* target/*-runner.jar target/lib"}
+			})
+
+			it("passes with a single candidate", func() {
+				Expect(ioutil.WriteFile(filepath.Join(path, "test-file"), []byte{}, 0644)).To(Succeed())
+				Expect(resolver.ResolveMany(path)).To(Equal([]string{filepath.Join(path, "test-file")}))
+			})
+
+			it("passes with multiple space separated globs", func() {
+				Expect(os.Mkdir(filepath.Join(path, "target"), os.ModePerm)).To(Succeed())
+
+				runnerJarPath := filepath.Join(path, "target", "function-1.0.0-SNAPSHOT-runner.jar")
+				Expect(ioutil.WriteFile(runnerJarPath, []byte{}, 0644)).To(Succeed())
+
+				libPath := filepath.Join(path, "target", "lib")
+				Expect(os.Mkdir(libPath, os.ModePerm)).To(Succeed())
+
+				Expect(resolver.ResolveMany(path)).To(Equal([]string{runnerJarPath, libPath}))
+			})
+
+			it("fails with zero candidates", func() {
+				_, err := resolver.ResolveMany(path)
+
+				Expect(err).To(MatchError(HavePrefix("unable to find any built artifacts for pattern(s):\ntest-*\ntarget/*-runner.jar\ntarget/lib")))
+			})
+		})
+
+		context("ResolveMany with a bad pattern", func() {
+			it.Before(func() {
+				resolver.ConfigurationResolver.Configurations[0] = libpak.BuildpackConfiguration{
+					Name: "TEST_ARTIFACT_CONFIGURATION_KEY", Default: "["}
+			})
+
+			it("fails with a single error", func() {
+				_, err := resolver.ResolveMany(path)
+
+				Expect(err).To(MatchError("unable to proceed due to bad pattern(s):\n["))
+			})
+		})
+
+		context("ResolveMany with many bad patterns", func() {
+			it.Before(func() {
+				resolver.ConfigurationResolver.Configurations[0] = libpak.BuildpackConfiguration{
+					Name: "TEST_ARTIFACT_CONFIGURATION_KEY", Default: "first-bad-[ test-* second-bad-["}
+			})
+
+			it("fails with multiple errors", func() {
+				_, err := resolver.ResolveMany(path)
+
+				Expect(err).To(MatchError("unable to proceed due to bad pattern(s):\nfirst-bad-[\nsecond-bad-["))
+			})
 		})
 	})
 }


### PR DESCRIPTION
- Errors will only occur from `filepath.Glob` if there's a bad pattern (it doesn't return i/o errors). Thus we can collect bad patterns and return them all at once. It'll be a slightly nicer user experience when there are errors.
- Add more tests around parsing patterns
- Fix some Paketo Java buildpacks style issues